### PR TITLE
FunctionID: Add option to disable namespace stripping

### DIFF
--- a/Ghidra/Features/FunctionID/ghidra_scripts/CreateMultipleLibraries.java
+++ b/Ghidra/Features/FunctionID/ghidra_scripts/CreateMultipleLibraries.java
@@ -58,6 +58,7 @@ public class CreateMultipleLibraries extends GhidraScript {
 	private File commonSymbolsFile = null;
 	private List<String> commonSymbols = null;
 	private LanguageID languageID = null;
+	private boolean disableNamespaceStripping = false;
 
 	private MyFidPopulateResultReporter reporter = null;
 
@@ -280,7 +281,7 @@ public class CreateMultipleLibraries extends GhidraScript {
 
 			FidPopulateResult result = service.createNewLibraryFromPrograms(fidDb,
 				currentLibraryName, currentLibraryVersion, currentLibraryVariant, programs, null,
-				languageID, null, commonSymbols, TaskMonitor.DUMMY);
+				languageID, null, commonSymbols, disableNamespaceStripping, TaskMonitor.DUMMY);
 			reporter.report(result);
 		}
 		catch (CancelledException e) {
@@ -369,6 +370,9 @@ public class CreateMultipleLibraries extends GhidraScript {
 		}
 		String lang = askString("Enter LanguageID To Process", "Language ID: ");
 		languageID = new LanguageID(lang);
+
+		disableNamespaceStripping =
+			askYesNo("Disable namespace stripping", "Do you want to disable namespace stripping?");
 
 		parseSymbols();
 		reporter = new MyFidPopulateResultReporter();

--- a/Ghidra/Features/FunctionID/src/main/java/ghidra/feature/fid/plugin/IngestTask.java
+++ b/Ghidra/Features/FunctionID/src/main/java/ghidra/feature/fid/plugin/IngestTask.java
@@ -45,10 +45,12 @@ public class IngestTask extends Task {
 	private File commonSymbolsFile;
 	private FidService fidService;
 	private FidPopulateResultReporter reporter;
+	private boolean disableNamespaceStripping;
 
 	public IngestTask(String title, FidFile fidFile, LibraryRecord libraryRecord,
 			DomainFolder folder, String libraryFamilyName, String libraryVersion,
-			String libraryVariant, String languageId, File commonSymbolsFile, FidService fidService,
+			String libraryVariant, String languageId, File commonSymbolsFile,
+			boolean disableNamespaceStripping, FidService fidService,
 			FidPopulateResultReporter reporter) {
 		super(title, true, false, false, false);
 		this.fidFile = fidFile;
@@ -61,6 +63,7 @@ public class IngestTask extends Task {
 		this.fidService = fidService;
 		this.reporter = reporter;
 		this.languageId = new LanguageID(languageId);
+		this.disableNamespaceStripping = disableNamespaceStripping;
 	}
 
 	@Override
@@ -95,6 +98,7 @@ public class IngestTask extends Task {
 			FidPopulateResult result = fidService.createNewLibraryFromPrograms(fidDb,
 				libraryFamilyName, libraryVersion, libraryVariant, programs, null, languageId,
 				libraryRecord == null ? null : Arrays.asList(libraryRecord), commonSymbols,
+				disableNamespaceStripping,
 				monitor);
 			reporter.report(result);
 			fidDb.saveDatabase("Saving", monitor);

--- a/Ghidra/Features/FunctionID/src/main/java/ghidra/feature/fid/plugin/PopulateFidDialog.java
+++ b/Ghidra/Features/FunctionID/src/main/java/ghidra/feature/fid/plugin/PopulateFidDialog.java
@@ -63,6 +63,7 @@ public class PopulateFidDialog extends DialogComponentProvider {
 	private FidService fidService;
 	private JTextField languageIdField;
 	private JTextField symbolsFileTextField;
+	private JCheckBox namespaceStrippingCheckBox;
 
 	protected PopulateFidDialog(PluginTool tool, FidService fidService) {
 		super("Populate Fid Database");
@@ -87,12 +88,17 @@ public class PopulateFidDialog extends DialogComponentProvider {
 		DomainFolder folder = getDomainFolder();
 		String languageFilter = languageIdField.getText().trim();
 		File commonSymbolsFile = getCommonSymbolsFile();
+		boolean disableNamespaceStripping = getNamespaceOption();
 
 		Task task = new IngestTask("Populate Library Task", fidFile, libraryRecord, folder,
 			libraryFamilyName, libraryVersion, libraryVariant, languageFilter, commonSymbolsFile,
-			fidService, new DefaultFidPopulateResultReporter());
+			disableNamespaceStripping, fidService, new DefaultFidPopulateResultReporter());
 		close();
 		tool.execute(task);
+	}
+
+	private boolean getNamespaceOption() {
+		return namespaceStrippingCheckBox.isSelected();
 	}
 
 	private File getCommonSymbolsFile() {
@@ -143,6 +149,11 @@ public class PopulateFidDialog extends DialogComponentProvider {
 
 		panel.add(new GLabel("Common Symbols File: ", SwingConstants.RIGHT));
 		panel.add(buildSymbolsFileField(), jLabel);
+
+		panel.add(new GLabel("Disable namespace stripping (experimental)", SwingConstants.RIGHT));
+		namespaceStrippingCheckBox = new JCheckBox();
+		namespaceStrippingCheckBox.addActionListener(e -> updateOkEnablement());
+		panel.add(namespaceStrippingCheckBox);
 
 		return panel;
 	}

--- a/Ghidra/Features/FunctionID/src/main/java/ghidra/feature/fid/service/FidService.java
+++ b/Ghidra/Features/FunctionID/src/main/java/ghidra/feature/fid/service/FidService.java
@@ -182,6 +182,7 @@ public class FidService {
 	 * @param linkLibraries libraries to search for (internally) unresolved symbols
 	 * @param commonSymbols is a list of symbols for which relationships are not generated
 	 * @param monitor a task monitor
+	 * @param disableNamespaceStripping boolean to disable namespace stripping
 	 * @throws MemoryAccessException if bytes are unavailable for a function body
 	 * @throws VersionException if any program cannot be opened without an upgrade
 	 * @throws CancelledException if the user cancels
@@ -191,12 +192,13 @@ public class FidService {
 	public FidPopulateResult createNewLibraryFromPrograms(FidDB fidDb, String libraryFamilyName,
 			String libraryVersion, String libraryVariant, List<DomainFile> programDomainFiles,
 			Predicate<Pair<Function, FidHashQuad>> functionFilter, LanguageID languageId,
-			List<LibraryRecord> linkLibraries, List<String> commonSymbols, TaskMonitor monitor)
+			List<LibraryRecord> linkLibraries, List<String> commonSymbols,
+			boolean disableNamespaceStripping, TaskMonitor monitor)
 			throws MemoryAccessException, VersionException, CancelledException,
 			IllegalStateException, IOException {
 		FidServiceLibraryIngest ingest = new FidServiceLibraryIngest(fidDb, this, libraryFamilyName,
 			libraryVersion, libraryVariant, programDomainFiles, functionFilter, languageId,
-			linkLibraries, monitor);
+			linkLibraries, monitor, disableNamespaceStripping);
 		ingest.markCommonChildReferences(commonSymbols);
 		return ingest.create();
 	}


### PR DESCRIPTION
Fixes #5858 

## Overview

The linked issue isnt tracked or assigned but it has been getting a lot of attention. I also run into this namespace stripping problem all the time when reversing Rust binaries and using function IDs.

When we create function ID database (.fidb) files, the populate functions strip the function namespaces. This is a [well documented limitation/feature](https://github.com/NationalSecurityAgency/ghidra/blob/master/Ghidra/Features/FunctionID/src/main/help/help/topics/FunctionID/FunctionID.html#L271) of the FID implementation.

The linked issue describes the problem: C++ (and Rust) code often has simple names that clash when you remove the namespace. I added a checkbox under `Tools -> Function ID -> Populate FidDb from programs...` which can be used to disable namespace stripping. This checkbox is disabled by default so it does not affect the original behavior if left unchecked. Here is the key change in `FidServiceLibraryIngest.java` at this line:

before:

```java
name = function.getSymbol().getName();
```

after:

```java
name = function.getSymbol().getName(disableNamespaceStripping);
```

where `function` is of type `Function` which is an interface extending `Namespace` so [this](https://github.com/NationalSecurityAgency/ghidra/blob/master/Ghidra/Framework/SoftwareModeling/src/main/java/ghidra/program/model/symbol/Namespace.java#L67) method is available:

```java
	/**
	 * Returns the fully qualified name
	 * @param includeNamespacePath true to include the namespace in the returned name
	 * @return the fully qualified name
	 */
	public String getName(boolean includeNamespacePath);
```

Using that we get the full symbol names including namespaces. The rest of the changes make sure the checkbox is added to the panel under `Tools -> Function ID -> Populate FidDb from programs...` and the setting gets passed through the code properly. I also updated `CreateMultipleLibraries.java` for headless mode.

## Testing

Before:

![image](https://github.com/user-attachments/assets/43fc64f6-af1c-473e-af99-bd29423f96f2)

Note that the namespaces of `drop_slow` are stripped.

After:

![image](https://github.com/user-attachments/assets/21d61f25-1fe3-4899-905f-838e69677ab7)

![image](https://github.com/user-attachments/assets/d4c91e16-8526-4adb-a34a-b4a37a027135)

Note that the namespaces of `drop_slow` are not stripped.

## Known issue

After running a FID analysis and applying symbols from a .fidb file (containing function names with namespaces), the namespaces end up getting embedded in the function name:

![image](https://github.com/user-attachments/assets/64aeb1ff-0e43-4ec2-a30f-4ff6715c665e)

This is why I marked this feature as experimental for now. I think this is a small issue compared to the huge gain we can achieve with keeping the namespaces.

I intend to improve/fix this in the future.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an experimental option to disable namespace stripping when creating or ingesting function ID libraries. This option is available via a new checkbox in the library creation dialog.
- **Documentation**
  - Updated help text to document the new namespace stripping option in relevant dialogs and methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->