### PR TITLE
Concise creation of simple DynamicTableColumns

### DIFF
--- a/Ghidra/Framework/Docking/src/main/java/docking/widgets/table/TableColumnDescriptor.java
+++ b/Ghidra/Framework/Docking/src/main/java/docking/widgets/table/TableColumnDescriptor.java
@@ -17,6 +17,8 @@ package docking.widgets.table;
 
 import java.util.*;
 
+import ghidra.docking.settings.Settings;
+import ghidra.framework.plugintool.ServiceProvider;
 import ghidra.util.Msg;
 
 public class TableColumnDescriptor<ROW_TYPE> {
@@ -96,6 +98,54 @@ public class TableColumnDescriptor<ROW_TYPE> {
 	}
 
 	/**
+	 * Adds a column to the descriptor via an anonymous accessor function instead of an anonymous object
+	 *
+	 * The column type needs to be explicitly specified because there is no way to prevent erasure of the generic
+	 * types of an anonymous function
+	 *
+	 */
+	public <COLUMN_TYPE> void addColumn(String name, Class<COLUMN_TYPE> columnTypeClass, RowObjectAccessor<ROW_TYPE, COLUMN_TYPE> rowObjectAccessor, boolean visible) {
+		AbstractDynamicTableColumn<ROW_TYPE, COLUMN_TYPE, Object> column = new AbstractDynamicTableColumn<>() {
+			@Override
+			public String getColumnName() {
+				return name;
+			}
+
+			@Override
+			public COLUMN_TYPE getValue(ROW_TYPE rowObject, Settings settings, Object data, ServiceProvider serviceProvider) throws IllegalArgumentException {
+				return rowObjectAccessor.access(rowObject);
+			}
+
+			@Override
+			public Class<COLUMN_TYPE> getColumnClass() {
+				return columnTypeClass;
+			}
+
+			@Override
+			public Class<ROW_TYPE> getSupportedRowType() {
+				// The reflection tricks in the regular implementation won't work and will always return null
+				// because of type erasure
+				return null;
+			}
+		};
+		if (visible)  {
+			addVisibleColumn(column);
+		} else {
+			addHiddenColumn(column);
+		}
+	}
+	/**
+	 * Adds a visible column to the descriptor via an anonymous accessor function instead of an anonymous object
+	 *
+	 * The column type needs to be explicitly specified because there is no way to prevent erasure of the generic
+	 * types of an anonymous function
+	 *
+	 */
+	public <COLUMN_TYPE> void addColumn(String name, Class<COLUMN_TYPE> columnTypeClass, RowObjectAccessor<ROW_TYPE, COLUMN_TYPE> rowObjectAccessor) {
+		addColumn(name, columnTypeClass, rowObjectAccessor, true);
+	}
+
+	/**
 	 * @param column the column to add
 	 * @param sortOrdinal the <b>ordinal (i.e., 1, 2, 3...n)</b>, not the index (i.e, 0, 1, 2...n).
 	 * @param ascending true to sort ascending
@@ -129,4 +179,16 @@ public class TableColumnDescriptor<ROW_TYPE> {
 			return sortIndex - o.sortIndex;
 		}
 	}
+
+	/**
+	 * A functional interface for accessing a column value from a row object
+	 * This allows for the creation of columns with anonymous functions via {@link #addColumn}
+	 * @param <ROW_TYPE>
+	 * @param <COLUMN_TYPE>
+	 */
+	@FunctionalInterface
+	public interface RowObjectAccessor<ROW_TYPE, COLUMN_TYPE> {
+		public COLUMN_TYPE access(ROW_TYPE rowObject) throws IllegalArgumentException;
+	}
+
 }


### PR DESCRIPTION
This is a feature proposal and proof of concept to allow concise definition of DynamicTableColumns

I have been working a lot with tables recently where I use a Java record as a `ROW_TYPE` and want to quickly define the columns. E.g. for a example record

```java
public record FunctionWithExtraInfo(Function func, String extraText, Integer someMagicNumber) {}
```


Currently, to my best knowledge, the best way to now create the `TableColumnDescriptor` for this is:

```java
	protected TableColumnDescriptor<FunctionWithExtraInfo> createTableColumnDescriptor() {
		TableColumnDescriptor<FunctionWithExtraInfo> descriptor = new TableColumnDescriptor<>();

                descriptor.addVisibleColumn(new AbstractDynamicTableColumn<FunctionWithExtraInfo, Function, Object>(){

			@Override
			public String getColumnName() {
				return "Function";
			}

			@Override
			public Function getValue(FunctionWithExtraInfo rowObject, Settings settings, Object data, ServiceProvider serviceProvider) throws IllegalArgumentException {
				return rowObject.func()
			}
		});

		descriptor.addVisibleColumn(new AbstractDynamicTableColumn<FunctionWithExtraInfo, String, Object>(){

			@Override
			public String getColumnName() {
				return "Extra Text";
			}

			@Override
			public String getValue(FunctionWithExtraInfo rowObject, Settings settings, Object data, ServiceProvider serviceProvider) throws IllegalArgumentException {
				return rowObject.extraText();
			}
		});
                descriptor.addVisibleColumn(new AbstractDynamicTableColumn<FunctionWithExtraInfo, Integer, Object>(){

			@Override
			public String getColumnName() {
				return "Magic Number";
			}

			@Override
			public Integer getValue(FunctionWithExtraInfo rowObject, Settings settings, Object data, ServiceProvider serviceProvider) throws IllegalArgumentException {
				return rowObject.magicNumber()
			}
		});
}
```

This PR adds an extra PoC method to `TableColumnDescriptor` that allows achieving the same in significantly less lines, and with just the important information:

```java

protected TableColumnDescriptor<FunctionWithExtraInfo> createTableColumnDescriptor() {
		TableColumnDescriptor<FunctionWithExtraInfo> descriptor = new TableColumnDescriptor<>();

                descriptor.addVisibleColumn("Function", Function.class, FunctionWithExtraInfo::func);
                descriptor.addVisibleColumn("Extra Info", String.class, FunctionWithExtraInfo::extraInfo);
                descriptor.addVisibleColumn("Magic Number", Integer.class, FunctionWithExtraInfo::magicNumber);
}
```

The second argument that explicitly specifies is needed because the type information will otherwise be lost at runtime. I consider this a small price to pay in terms of verbosity, as it is still significantly less lines than by default, and the Compiler still enforces that this type matches the return value of the accessor, so there is no risk of accidentally mixing types AFAIU.


I'd first like feedback if this approach has any drawbacks I'm not aware of, or if there is a better way to add `TableColumn`s that I missed. If this is a worthwhile addition I can extend the extra methods to also cover the cases for hidden columns, and potentially sorting. It should also be possible to add a method that takes an accessor function that has the full signature `public COLUMN_TYPE getValue(ROW_TYPE rowObject, Settings settings, Object data, ServiceProvider serviceProvider)` instead of just `public COLUMN_TYPE getValue(ROW_TYPE rowObject)` if this is considered worthwhile.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for creating table columns using simple functions or lambdas, making it easier to define and add new columns.
  - Users can now specify whether new columns should be visible or hidden by default when adding them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->