### PR TITLE
Reduce far pointers to near in segmented code

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
@@ -1989,7 +1989,7 @@ int4 ActionSetCasts::castOutput(PcodeOp *op,Funcdata &data,CastStrategy *castStr
         }
       }
     }
-      if (outvn->getType() != tokenct)
+    if (outvn->getType() != tokenct)
       force=true;		// Make sure not to drop pointer type
   }
   if (!force) {

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
@@ -1262,10 +1262,15 @@ void ActionFuncLink::funcLinkOutput(FuncCallSpecs *fc,Funcdata &data)
       data.newVarnodeOut(sz,addr,fc->getOp());
       SegmentOp* segdef = data.canSegmentizeFarPtr(outparam->getType(),
         outparam->isTypeLocked(), sz);
-	if (segdef != (SegmentOp*)0) {
-	  data.segmentizeFarPtr(sz, fc->getOp(),
-	    data.newVarnode(segdef->getBaseSize(), addr + segdef->getInnerSize()),
-	    data.newVarnode(segdef->getInnerSize(), addr), fc->getOp()->getOut());
+      if (segdef != (SegmentOp*)0) {
+	  PcodeOp* op = data.newOp(1, fc->getOp()->getAddr());
+	  data.opSetOpcode(op, CPUI_COPY); //must because of join spaces
+	  data.newUniqueOut(sz, op);
+	  data.opSetInput(op, fc->getOp()->getOut(), 0);
+	  data.opInsertAfter(op, fc->getOp());
+	  data.segmentizeFarPtr(sz, op,
+	    data.newVarnode(segdef->getBaseSize(), op->getOut()->getAddr() + segdef->getInnerSize()),
+	    data.newVarnode(segdef->getInnerSize(), op->getOut()->getAddr()), data.newVarnode(sz, addr));
       }
       VarnodeData vdata;
       OpCode res = fc->assumedOutputExtension(addr,sz,vdata);

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
@@ -1966,29 +1966,29 @@ int4 ActionSetCasts::castOutput(PcodeOp *op,Funcdata &data,CastStrategy *castStr
       // Preserve implied pointer if it points to a composite
       if ((meta!=TYPE_ARRAY)&&(meta!=TYPE_STRUCT))
 	outvn->updateType(tokenct,false,false); // Otherwise ignore it in favor of the token type
-      }  else {
-		if (op->code() == CPUI_PIECE) {
-			Architecture* glb = data.getArch();
-			AddrSpace* rspc = glb->getDefaultSpace();
-			bool arenearpointers = glb->hasNearPointers(rspc);
-			if (arenearpointers && rspc->getAddrSize() == op->getOut()->getSize()) {
-				SegmentOp* segdef = glb->userops.getSegmentOp(rspc->getIndex());
-				if (segdef->getBaseSize() == op->getIn(0)->getSize() &&
-					segdef->getInnerSize() == op->getIn(1)->getSize() &&
-					op->getIn(1)->getType()->getMetatype() == TYPE_PTR) { //far pointer found
-					//data.opSetOpcode(op, CPUI_CALLOTHER); //this is ideal but its way too late
-					//data.opInsertInput(op, op->getIn(1), 2); //need to check size of offset
-					//data.opSetInput(op, op->getIn(0), 1); //need to check size of segment
-					//data.opSetInput(op, data.newConstant(4, glb->userops.getSegmentOp(rspc->getIndex())->getIndex()), 0);
-					//data.opSetOpcode(op, CPUI_SEGMENTOP); //possible but again segmentizing occurs much earlier
-					//data.opSetInput(op, data.newVarnodeSpace(containerid), 0); //spacebase
-					data.opSetOpcode(op, CPUI_COPY);
-					data.opSwapInput(op, 0, 1);
-					data.opRemoveInput(op, 1);
-				}
-			}
-		}
-	}
+    } else {
+      if (op->code() == CPUI_PIECE) {
+        Architecture* glb = data.getArch();
+        AddrSpace* rspc = glb->getDefaultSpace();
+        bool arenearpointers = glb->hasNearPointers(rspc);
+        if (arenearpointers && rspc->getAddrSize() == op->getOut()->getSize()) {
+          SegmentOp* segdef = glb->userops.getSegmentOp(rspc->getIndex());
+          if (segdef->getBaseSize() == op->getIn(0)->getSize() &&
+            segdef->getInnerSize() == op->getIn(1)->getSize() &&
+            op->getIn(1)->getType()->getMetatype() == TYPE_PTR) { //far pointer found
+            //data.opSetOpcode(op, CPUI_CALLOTHER); //this is ideal but its way too late
+            //data.opInsertInput(op, op->getIn(1), 2); //need to check size of offset
+            //data.opSetInput(op, op->getIn(0), 1); //need to check size of segment
+            //data.opSetInput(op, data.newConstant(4, glb->userops.getSegmentOp(rspc->getIndex())->getIndex()), 0);
+            //data.opSetOpcode(op, CPUI_SEGMENTOP); //possible but again segmentizing occurs much earlier
+            //data.opSetInput(op, data.newVarnodeSpace(containerid), 0); //spacebase
+            data.opSetOpcode(op, CPUI_COPY);
+            data.opSwapInput(op, 0, 1);
+            data.opRemoveInput(op, 1);
+          }
+        }
+      }
+    }
       if (outvn->getType() != tokenct)
       force=true;		// Make sure not to drop pointer type
   }

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
@@ -1214,7 +1214,7 @@ void ActionFuncLink::funcLinkInput(FuncCallSpecs *fc,Funcdata &data)
       int4 sz = param->getSize();
       if (spc->getType() == IPTR_SPACEBASE) { // Param is stack relative
 	Varnode *loadval = data.opStackLoad(spc,off,sz,op,(Varnode *)0,false);
-	data.segmentizeFarPtr(param->getType(), param->isTypeLocked(), loadval, false);
+	data.segmentizeFarPtr(param->getType(), param->isTypeLocked(), loadval, false, false);
 	data.opInsertInput(op,loadval,op->numInput());
 	if (!setplaceholder) {
 	  setplaceholder = true;
@@ -1224,7 +1224,7 @@ void ActionFuncLink::funcLinkInput(FuncCallSpecs *fc,Funcdata &data)
       }
       else {
 		    Varnode* loadval = data.newVarnode(param->getSize(), param->getAddress());
-		    data.segmentizeFarPtr(param->getType(), param->isTypeLocked(), loadval, false);
+		    data.segmentizeFarPtr(param->getType(), param->isTypeLocked(), loadval, false, false);
 		    data.opInsertInput(op, loadval, op->numInput());
 	    }
     }
@@ -1255,7 +1255,7 @@ void ActionFuncLink::funcLinkOutput(FuncCallSpecs *fc,Funcdata &data)
       int4 sz = outparam->getSize();
       Address addr = outparam->getAddress();
       data.newVarnodeOut(sz,addr,fc->getOp());
-      data.segmentizeFarPtr(outparam->getType(), outparam->isTypeLocked(), fc->getOp()->getOut(), false);
+      data.segmentizeFarPtr(outparam->getType(), outparam->isTypeLocked(), fc->getOp()->getOut(), false, true);
       VarnodeData vdata;
       OpCode res = fc->assumedOutputExtension(addr,sz,vdata);
       if (res == CPUI_PIECE) {		// Pick an extension based on type
@@ -4299,7 +4299,7 @@ int4 ActionInferTypes::apply(Funcdata &data)
 		  ct = vn->getLocalType();
 		  bool bBegin = false;
 		  if (iter == data.beginLoc()) bBegin = true; else iter--;
-		  data.segmentizeFarPtr(ct, vn->isTypeLock(), vn, true);
+		  data.segmentizeFarPtr(ct, vn->isTypeLock(), vn, true, true);
 		  if (bBegin) iter = data.beginLoc(); else iter++;
 	  }
   }	

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
@@ -1222,7 +1222,7 @@ void ActionFuncLink::funcLinkInput(FuncCallSpecs *fc,Funcdata &data)
 	}
       }
       else
-	data.opInsertInput(op, data.newVarnode(param->getSize(), param->getAddress()), op->numInput());
+	data.opInsertInput(op,data.newVarnode(param->getSize(),param->getAddress()),op->numInput());
       data.segmentizeFarPtr(param->getType(), param->isTypeLocked(), op->getIn(op->numInput() - 1), false);
     }
   }

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
@@ -1214,7 +1214,7 @@ void ActionFuncLink::funcLinkInput(FuncCallSpecs *fc,Funcdata &data)
       int4 sz = param->getSize();
       if (spc->getType() == IPTR_SPACEBASE) { // Param is stack relative
 	Varnode *loadval = data.opStackLoad(spc,off,sz,op,(Varnode *)0,false);
-	data.segmentizeFarPtr(param->getType(), param->isTypeLocked(), loadval, false, false);
+	data.segmentizeFarPtr(param->getType(), param->isTypeLocked(), loadval, false);
 	data.opInsertInput(op,loadval,op->numInput());
 	if (!setplaceholder) {
 	  setplaceholder = true;
@@ -1224,7 +1224,7 @@ void ActionFuncLink::funcLinkInput(FuncCallSpecs *fc,Funcdata &data)
       }
       else {
 		    Varnode* loadval = data.newVarnode(param->getSize(), param->getAddress());
-		    data.segmentizeFarPtr(param->getType(), param->isTypeLocked(), loadval, false, false);
+		    data.segmentizeFarPtr(param->getType(), param->isTypeLocked(), loadval, false);
 		    data.opInsertInput(op, loadval, op->numInput());
 	    }
     }
@@ -1255,7 +1255,7 @@ void ActionFuncLink::funcLinkOutput(FuncCallSpecs *fc,Funcdata &data)
       int4 sz = outparam->getSize();
       Address addr = outparam->getAddress();
       data.newVarnodeOut(sz,addr,fc->getOp());
-      data.segmentizeFarPtr(outparam->getType(), outparam->isTypeLocked(), fc->getOp()->getOut(), false, true);
+      data.segmentizeFarPtr(outparam->getType(), outparam->isTypeLocked(), fc->getOp()->getOut(), false);
       VarnodeData vdata;
       OpCode res = fc->assumedOutputExtension(addr,sz,vdata);
       if (res == CPUI_PIECE) {		// Pick an extension based on type
@@ -4299,7 +4299,7 @@ int4 ActionInferTypes::apply(Funcdata &data)
 		  ct = vn->getLocalType();
 		  bool bBegin = false;
 		  if (iter == data.beginLoc()) bBegin = true; else iter--;
-		  data.segmentizeFarPtr(ct, vn->isTypeLock(), vn, true, true);
+		  data.segmentizeFarPtr(ct, vn->isTypeLock(), vn, true);
 		  if (bBegin) iter = data.beginLoc(); else iter++;
 	  }
   }	

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
@@ -1213,7 +1213,7 @@ void ActionFuncLink::funcLinkInput(FuncCallSpecs *fc,Funcdata &data)
       uintb off = param->getAddress().getOffset();
       int4 sz = param->getSize();
       if (spc->getType() == IPTR_SPACEBASE) { // Param is stack relative
-	Varnode *loadval = data.opStackLoad(spc, off, sz, op, (Varnode*)0, false);
+	Varnode *loadval = data.opStackLoad(spc,off,sz,op,(Varnode *)0,false);
 	data.opInsertInput(op,loadval,op->numInput());
 	if (!setplaceholder) {
 	  setplaceholder = true;
@@ -1222,7 +1222,7 @@ void ActionFuncLink::funcLinkInput(FuncCallSpecs *fc,Funcdata &data)
 	}
       }
       else
-       data.opInsertInput(op,data.newVarnode(param->getSize(),param->getAddress()),op->numInput());
+	data.opInsertInput(op,data.newVarnode(param->getSize(),param->getAddress()),op->numInput());
     }
   }
   if (spacebase != (AddrSpace *)0) {	// If we need it, create the stackplaceholder

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
@@ -1214,7 +1214,6 @@ void ActionFuncLink::funcLinkInput(FuncCallSpecs *fc,Funcdata &data)
       int4 sz = param->getSize();
       if (spc->getType() == IPTR_SPACEBASE) { // Param is stack relative
 	Varnode *loadval = data.opStackLoad(spc,off,sz,op,(Varnode *)0,false);
-	data.segmentizeFarPtr(param->getType(), param->isTypeLocked(), loadval, false);
 	data.opInsertInput(op,loadval,op->numInput());
 	if (!setplaceholder) {
 	  setplaceholder = true;
@@ -1222,11 +1221,9 @@ void ActionFuncLink::funcLinkInput(FuncCallSpecs *fc,Funcdata &data)
 	  spacebase = (AddrSpace *)0;	// With a locked stack parameter, we don't need a stackplaceholder
 	}
       }
-      else {
-		    Varnode* loadval = data.newVarnode(param->getSize(), param->getAddress());
-		    data.segmentizeFarPtr(param->getType(), param->isTypeLocked(), loadval, false);
-		    data.opInsertInput(op, loadval, op->numInput());
-	    }
+      else
+	data.opInsertInput(op, data.newVarnode(param->getSize(), param->getAddress()), op->numInput());
+      data.segmentizeFarPtr(param->getType(), param->isTypeLocked(), op->getIn(op->numInput() - 1), false);
     }
   }
   if (spacebase != (AddrSpace *)0) {	// If we need it, create the stackplaceholder

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
@@ -1213,7 +1213,7 @@ void ActionFuncLink::funcLinkInput(FuncCallSpecs *fc,Funcdata &data)
       uintb off = param->getAddress().getOffset();
       int4 sz = param->getSize();
       if (spc->getType() == IPTR_SPACEBASE) { // Param is stack relative
-	Varnode* loadval = data.opStackLoad(spc, off, sz, op, (Varnode*)0, false);
+	Varnode *loadval = data.opStackLoad(spc, off, sz, op, (Varnode*)0, false);
 	data.opInsertInput(op,loadval,op->numInput());
 	if (!setplaceholder) {
 	  setplaceholder = true;
@@ -1222,7 +1222,7 @@ void ActionFuncLink::funcLinkInput(FuncCallSpecs *fc,Funcdata &data)
 	}
       }
       else
-        data.opInsertInput(op,data.newVarnode(param->getSize(),param->getAddress()),op->numInput());
+       data.opInsertInput(op,data.newVarnode(param->getSize(),param->getAddress()),op->numInput());
     }
   }
   if (spacebase != (AddrSpace *)0) {	// If we need it, create the stackplaceholder
@@ -4282,7 +4282,6 @@ int4 ActionInferTypes::apply(Funcdata &data)
     }
     return 0;
   }
-
   if (localcount == 0) {
 	  Datatype* ct;
 	  Varnode* vn;

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
@@ -1220,7 +1220,8 @@ void ActionFuncLink::funcLinkInput(FuncCallSpecs *fc,Funcdata &data)
 	  loadval->setSpacebasePlaceholder();
 	  spacebase = (AddrSpace *)0;	// With a locked stack parameter, we don't need a stackplaceholder
 	}
-      } else
+      }
+      else
         data.opInsertInput(op,data.newVarnode(param->getSize(),param->getAddress()),op->numInput());
     }
   }
@@ -4281,7 +4282,7 @@ int4 ActionInferTypes::apply(Funcdata &data)
     }
     return 0;
   }
-	
+
   if (localcount == 0) {
 	  Datatype* ct;
 	  Varnode* vn;

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/coreaction.cc
@@ -1966,8 +1966,30 @@ int4 ActionSetCasts::castOutput(PcodeOp *op,Funcdata &data,CastStrategy *castStr
       // Preserve implied pointer if it points to a composite
       if ((meta!=TYPE_ARRAY)&&(meta!=TYPE_STRUCT))
 	outvn->updateType(tokenct,false,false); // Otherwise ignore it in favor of the token type
-    }
-    if (outvn->getType() != tokenct)
+      }  else {
+		if (op->code() == CPUI_PIECE) {
+			Architecture* glb = data.getArch();
+			AddrSpace* rspc = glb->getDefaultSpace();
+			bool arenearpointers = glb->hasNearPointers(rspc);
+			if (arenearpointers && rspc->getAddrSize() == op->getOut()->getSize()) {
+				SegmentOp* segdef = glb->userops.getSegmentOp(rspc->getIndex());
+				if (segdef->getBaseSize() == op->getIn(0)->getSize() &&
+					segdef->getInnerSize() == op->getIn(1)->getSize() &&
+					op->getIn(1)->getType()->getMetatype() == TYPE_PTR) { //far pointer found
+					//data.opSetOpcode(op, CPUI_CALLOTHER); //this is ideal but its way too late
+					//data.opInsertInput(op, op->getIn(1), 2); //need to check size of offset
+					//data.opSetInput(op, op->getIn(0), 1); //need to check size of segment
+					//data.opSetInput(op, data.newConstant(4, glb->userops.getSegmentOp(rspc->getIndex())->getIndex()), 0);
+					//data.opSetOpcode(op, CPUI_SEGMENTOP); //possible but again segmentizing occurs much earlier
+					//data.opSetInput(op, data.newVarnodeSpace(containerid), 0); //spacebase
+					data.opSetOpcode(op, CPUI_COPY);
+					data.opSwapInput(op, 0, 1);
+					data.opRemoveInput(op, 1);
+				}
+			}
+		}
+	}
+      if (outvn->getType() != tokenct)
       force=true;		// Make sure not to drop pointer type
   }
   if (!force) {

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/funcdata.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/funcdata.cc
@@ -343,7 +343,7 @@ void Funcdata::spacebaseConstant(PcodeOp *op,int4 slot,SymbolEntry *entry,const 
   opSetInput(op,outvn,slot);
 }
 
-void Funcdata::segmentizeFarPtr(Datatype* ct, bool locked, Varnode* vn, bool segmentize, bool bAfter)
+void Funcdata::segmentizeFarPtr(Datatype* ct, bool locked, Varnode* vn, bool segmentize)
 {
 	SegmentOp* segdef = (SegmentOp*)0;
 	if ((ct->getMetatype() == TYPE_PTR ||
@@ -365,7 +365,7 @@ void Funcdata::segmentizeFarPtr(Datatype* ct, bool locked, Varnode* vn, bool seg
 		Varnode* vn1 = newUniqueOut(segdef->getBaseSize(), piece1);
 		opSetInput(piece1, outvn, 0);
 		opSetInput(piece1, newConstant(outvn->getSize(), segdef->getInnerSize()), 1);
-		if (bAfter) opInsertAfter(piece1, segroot); else opInsertBefore(piece1, segroot);
+		opInsertAfter(piece1, segroot);
 		PcodeOp* piece2 = newOp(2, segroot->getAddr());
 		opSetOpcode(piece2, CPUI_SUBPIECE);
 		Varnode* vn2 = newUniqueOut(segdef->getInnerSize(), piece2);

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/funcdata.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/funcdata.cc
@@ -343,7 +343,7 @@ void Funcdata::spacebaseConstant(PcodeOp *op,int4 slot,SymbolEntry *entry,const 
   opSetInput(op,outvn,slot);
 }
 
-void Funcdata::segmentizeFarPtr(Datatype* ct, bool locked, Varnode* vn, bool segmentize)
+void Funcdata::segmentizeFarPtr(Datatype* ct, bool locked, Varnode* vn, bool segmentize, bool bAfter)
 {
 	SegmentOp* segdef = (SegmentOp*)0;
 	if ((ct->getMetatype() == TYPE_PTR ||
@@ -365,7 +365,7 @@ void Funcdata::segmentizeFarPtr(Datatype* ct, bool locked, Varnode* vn, bool seg
 		Varnode* vn1 = newUniqueOut(segdef->getBaseSize(), piece1);
 		opSetInput(piece1, outvn, 0);
 		opSetInput(piece1, newConstant(outvn->getSize(), segdef->getInnerSize()), 1);
-		opInsertAfter(piece1, segroot);
+		if (bAfter) opInsertAfter(piece1, segroot); else opInsertBefore(piece1, segroot);
 		PcodeOp* piece2 = newOp(2, segroot->getAddr());
 		opSetOpcode(piece2, CPUI_SUBPIECE);
 		Varnode* vn2 = newUniqueOut(segdef->getInnerSize(), piece2);

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/funcdata.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/funcdata.hh
@@ -370,8 +370,6 @@ public:
   }
   ParamActive *getActiveOutput(void) const { return activeoutput; }	///< Get the \e return prototype recovery object
   void setHighLevel(void);					///< Turn on HighVariable objects for all Varnodes
-  SegmentOp* canSegmentizeFarPtr(Datatype* typ, bool locked, int4 sz);
-  Varnode* segmentizeFarPtr(int4 sz, PcodeOp* op, Varnode* segvn, Varnode* offvn, Varnode* outvn);
   void clearDeadVarnodes(void);					///< Delete any dead Varnodes
   void calcNZMask(void);					///< Calculate \e non-zero masks for all Varnodes
   void clearDeadOps(void) { obank.destroyDead(); }		///< Delete any dead PcodeOps

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/funcdata.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/funcdata.hh
@@ -196,7 +196,7 @@ public:
   Varnode *newSpacebasePtr(AddrSpace *id);	///< Construct a new \e spacebase register for a given address space
   Varnode *findSpacebaseInput(AddrSpace *id) const;
   void spacebaseConstant(PcodeOp *op,int4 slot,SymbolEntry *entry,const Address &rampoint,uintb origval,int4 origsize);
-  void segmentizeFarPtr(Datatype* ct, bool locked, Varnode* vn, bool segmentize, bool bAfter);
+  void segmentizeFarPtr(Datatype* ct, bool locked, Varnode* vn, bool segmentize);
 
   /// \brief Get the number of heritage passes performed for the given address space
   ///

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/funcdata.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/funcdata.hh
@@ -370,6 +370,8 @@ public:
   }
   ParamActive *getActiveOutput(void) const { return activeoutput; }	///< Get the \e return prototype recovery object
   void setHighLevel(void);					///< Turn on HighVariable objects for all Varnodes
+  SegmentOp* canSegmentizeFarPtr(Datatype* typ, bool locked, int4 sz);
+  Varnode* segmentizeFarPtr(int4 sz, PcodeOp* op, Varnode* segvn, Varnode* offvn);
   void clearDeadVarnodes(void);					///< Delete any dead Varnodes
   void calcNZMask(void);					///< Calculate \e non-zero masks for all Varnodes
   void clearDeadOps(void) { obank.destroyDead(); }		///< Delete any dead PcodeOps

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/funcdata.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/funcdata.hh
@@ -196,7 +196,7 @@ public:
   Varnode *newSpacebasePtr(AddrSpace *id);	///< Construct a new \e spacebase register for a given address space
   Varnode *findSpacebaseInput(AddrSpace *id) const;
   void spacebaseConstant(PcodeOp *op,int4 slot,SymbolEntry *entry,const Address &rampoint,uintb origval,int4 origsize);
-  void segmentizeFarPtr(Datatype* ct, bool locked, Varnode* vn, bool segmentize);
+  void segmentizeFarPtr(Datatype* ct, bool locked, Varnode* vn, bool segmentize, bool bAfter);
 
   /// \brief Get the number of heritage passes performed for the given address space
   ///

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/funcdata.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/funcdata.hh
@@ -371,7 +371,7 @@ public:
   ParamActive *getActiveOutput(void) const { return activeoutput; }	///< Get the \e return prototype recovery object
   void setHighLevel(void);					///< Turn on HighVariable objects for all Varnodes
   SegmentOp* canSegmentizeFarPtr(Datatype* typ, bool locked, int4 sz);
-  Varnode* segmentizeFarPtr(int4 sz, PcodeOp* op, Varnode* segvn, Varnode* offvn);
+  Varnode* segmentizeFarPtr(int4 sz, PcodeOp* op, Varnode* segvn, Varnode* offvn, Varnode* outvn);
   void clearDeadVarnodes(void);					///< Delete any dead Varnodes
   void calcNZMask(void);					///< Calculate \e non-zero masks for all Varnodes
   void clearDeadOps(void) { obank.destroyDead(); }		///< Delete any dead PcodeOps

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/funcdata.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/funcdata.hh
@@ -196,6 +196,7 @@ public:
   Varnode *newSpacebasePtr(AddrSpace *id);	///< Construct a new \e spacebase register for a given address space
   Varnode *findSpacebaseInput(AddrSpace *id) const;
   void spacebaseConstant(PcodeOp *op,int4 slot,SymbolEntry *entry,const Address &rampoint,uintb origval,int4 origsize);
+  void segmentizeFarPtr(Datatype* ct, bool locked, Varnode* vn, bool segmentize);
 
   /// \brief Get the number of heritage passes performed for the given address space
   ///

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/funcdata_varnode.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/funcdata_varnode.cc
@@ -500,13 +500,13 @@ Varnode* Funcdata::segmentizeFarPtr(int4 sz, PcodeOp* op,
   AddrSpace* rspc = glb->getDefaultSpace();
   SegmentOp* segdef = glb->userops.getSegmentOp(rspc->getIndex());
   PcodeOp* newop = newOp(3, op->getAddr());
-  outvn == (Varnode*)0 ? newUniqueOut(sz, newop) : opSetOutput(op, outvn);
+  if (outvn == (Varnode*)0) newUniqueOut(sz, newop); else opSetOutput(op, outvn);
   opSetOpcode(newop, CPUI_CALLOTHER);
   //endianness could matter here - e.g. CALLF addr16 on x86 uses segment(*:2 (ptr+2),*:2 ptr)
   opSetInput(newop, newConstant(4, segdef->getIndex()), 0);
   opSetInput(newop, segvn, 1); //need to check size of segment
   opSetInput(newop, offvn, 2); //need to check size of offset
-  outvn == (Varnode*)0 ? opInsertBefore(newop, op) : opInsertAfter(newop, op);
+  if (outvn == (Varnode*)0) opInsertBefore(newop, op); else opInsertAfter(newop, op);
   return newop->getOut();
 }
 

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/funcdata_varnode.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/funcdata_varnode.cc
@@ -479,37 +479,6 @@ void Funcdata::setHighLevel(void)
     assignHigh(*iter);
 }
 
-
-SegmentOp* Funcdata::canSegmentizeFarPtr(Datatype* typ, bool locked, int4 sz)
-{
-  if ((typ->getMetatype() == TYPE_PTR ||
-    typ->getMetatype() == TYPE_CODE) && locked) {
-    Architecture* glb = getArch();
-    AddrSpace* rspc = glb->getDefaultSpace();
-    bool arenearpointers = glb->hasNearPointers(rspc);
-    if (arenearpointers && rspc->getAddrSize() == sz)
-      return glb->userops.getSegmentOp(rspc->getIndex());
-    }
-  return (SegmentOp*)0;
-}
-
-Varnode* Funcdata::segmentizeFarPtr(int4 sz, PcodeOp* op,
-  Varnode* segvn, Varnode* offvn, Varnode* outvn)
-{
-  Architecture* glb = getArch();
-  AddrSpace* rspc = glb->getDefaultSpace();
-  SegmentOp* segdef = glb->userops.getSegmentOp(rspc->getIndex());
-  PcodeOp* newop = newOp(3, op->getAddr());
-  if (outvn == (Varnode*)0) newUniqueOut(sz, newop); else opSetOutput(op, outvn);
-  opSetOpcode(newop, CPUI_CALLOTHER);
-  //endianness could matter here - e.g. CALLF addr16 on x86 uses segment(*:2 (ptr+2),*:2 ptr)
-  opSetInput(newop, newConstant(4, segdef->getIndex()), 0);
-  opSetInput(newop, segvn, 1); //need to check size of segment
-  opSetInput(newop, offvn, 2); //need to check size of offset
-  if (outvn == (Varnode*)0) opInsertBefore(newop, op); else opInsertAfter(newop, op);
-  return newop->getOut();
-}
-
 /// \brief Create two new Varnodes which split the given Varnode
 ///
 /// Attributes are copied from the original into the split pieces if appropriate

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/funcdata_varnode.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/funcdata_varnode.cc
@@ -493,19 +493,20 @@ SegmentOp* Funcdata::canSegmentizeFarPtr(Datatype* typ, bool locked, int4 sz)
   return (SegmentOp*)0;
 }
 
-Varnode* Funcdata::segmentizeFarPtr(int4 sz, PcodeOp* op, Varnode* segvn, Varnode* offvn)
+Varnode* Funcdata::segmentizeFarPtr(int4 sz, PcodeOp* op,
+  Varnode* segvn, Varnode* offvn, Varnode* outvn)
 {
   Architecture* glb = getArch();
   AddrSpace* rspc = glb->getDefaultSpace();
   SegmentOp* segdef = glb->userops.getSegmentOp(rspc->getIndex());
   PcodeOp* newop = newOp(3, op->getAddr());
-  newUniqueOut(sz, newop);
+  outvn == (Varnode*)0 ? newUniqueOut(sz, newop) : opSetOutput(op, outvn);
   opSetOpcode(newop, CPUI_CALLOTHER);
   //endianness could matter here - e.g. CALLF addr16 on x86 uses segment(*:2 (ptr+2),*:2 ptr)
   opSetInput(newop, newConstant(4, segdef->getIndex()), 0);
   opSetInput(newop, segvn, 1); //need to check size of segment
   opSetInput(newop, offvn, 2); //need to check size of offset
-  opInsertBefore(newop, op);
+  outvn == (Varnode*)0 ? opInsertBefore(newop, op) : opInsertAfter(newop, op);
   return newop->getOut();
 }
 


### PR DESCRIPTION
This will make proper conversion far pointers to near pointers which are bound as far pointers in type parameters to functions for example which is otherwise not detected or properly translated.

The casting time is a too late and not ideal time for this code.  At function stack binding time is perfect as everything is present to detect it.  However it is tested and working and reasonably generic using the default segment e.g. global RAM for its basis, checking the segment op, checking matching sizes, and finally that a near pointer already is present which can cause discarding of the segment and this awkward CONCAT structure that gets emitted in code.

CALLOTHER or (not SEGMENTOP which needs the appropriate resolver to be chosen and in such a generic case analysis needed) is better but needs to be processed earlier or CONCAT just becomes SEGMENT in the code.  Otherwise this direct simplification (which ruleaction segment reducer should deal with) also works.

Sequences like this are now fixed:
PUSH SS
PUSH AX

Fixes other half of #817

This fixes a great deal of cases and is one of the greatest output quality improvements in segmented code to date.  This is the rigorous and serious attempt at a generalized fix which appears to now work correctly and is versatile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved support for far pointer segment information during decompilation, enhancing handling of function parameters, return values, and local variables that use far pointers.
- **Bug Fixes**
	- Ensured accurate propagation and adjustment of segment information for far pointers, reducing potential issues in type inference and pointer representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->