### PR TITLE
Updated ruleBlockIfNoExit to better select branch if both are noexit.

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/block.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/block.hh
@@ -181,6 +181,7 @@ public:
   /// \param enditer marks the end of the XML tags
   /// \param resolver is used to recover FlowBlock objects based on XML references
   virtual void restoreXmlBody(List::const_iterator &iter,List::const_iterator enditer,BlockMap &resolver) {}
+  virtual int4 getBlockDepth(void) {return 0;}		///< Return the depth in code block of \b this
   void saveXmlEdges(ostream &s) const;			///< Save edge information to an XML stream
   void restoreXmlEdges(List::const_iterator &iter,List::const_iterator enditer,BlockMap &resolver);
   void saveXml(ostream &s) const;			///< Write out \b this to an XML stream
@@ -299,6 +300,8 @@ public:
   virtual void finalizePrinting(const Funcdata &data) const;
   virtual void saveXmlBody(ostream &s) const;
   virtual void restoreXmlBody(List::const_iterator &iter,List::const_iterator enditer,BlockMap &resolver);
+  virtual int4 getInnerBlockDepth();					///< Return max depth of child blocks
+  virtual int4 getBlockDepth() {return getInnerBlockDepth()+1;}
   void restoreXml(const Element *el,const AddrSpaceManager *m);	///< Restore \b this BlockGraph from an XML stream
   void addEdge(FlowBlock *begin,FlowBlock *end);		///< Add a directed edge between component FlowBlocks
   void addLoopEdge(FlowBlock *begin,int4 outindex);		///< Mark a given edge as a \e loop edge
@@ -401,6 +404,7 @@ public:
   list<PcodeOp *>::const_iterator beginOp(void) const { return op.begin(); }	///< Return an iterator to the beginning of the PcodeOps
   list<PcodeOp *>::const_iterator endOp(void) const { return op.end(); }	///< Return an iterator to the end of the PcodeOps
   bool emptyOp(void) const { return op.empty(); }		///< Return \b true if \b block contains no operations
+  int4 getOpSize(void);					///< Number of PcodeOps contained in \b this block
   static bool noInterveningStatement(PcodeOp *first,int4 path,PcodeOp *last);
 };
 
@@ -501,6 +505,7 @@ public:
   virtual PcodeOp *lastOp(void) const;
   virtual bool negateCondition(bool toporbottom);
   virtual FlowBlock *getSplitPoint(void);
+  virtual int4 getBlockDepth(void);
 };
 
 /// \brief Two conditional blocks combined into one conditional using BOOL_AND or BOOL_OR
@@ -530,6 +535,7 @@ public:
   virtual bool isComplex(void) const { return getBlock(0)->isComplex(); }
   virtual FlowBlock *nextFlowAfter(const FlowBlock *bl) const;
   virtual void saveXmlHeader(ostream &s) const;
+  virtual int4 getBlockDepth(void);
 };
 
 /// \brief A basic "if" block
@@ -675,6 +681,7 @@ public:
   virtual void emit(PrintLanguage *lng) const { lng->emitBlockSwitch(this); }
   virtual FlowBlock *nextFlowAfter(const FlowBlock *bl) const;
   virtual void finalizePrinting(const Funcdata &data) const;
+  virtual int4 getBlockDepth(void);
 };
 
 /// \brief Helper class for resolving cross-references while deserializing BlockGraph objects

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/blockaction.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/blockaction.hh
@@ -217,6 +217,7 @@ class CollapseStructure {
   bool ruleCaseFallthru(FlowBlock *bl);		///< Attempt to one switch case falling through to another
   int4 collapseInternal(FlowBlock *targetbl);	///< The main collapsing loop
   void collapseConditions(void);		///< Simplify conditionals
+  int4 selectBestNoExit(FlowBlock *clause0,FlowBlock *clause1);
 public:
   CollapseStructure(BlockGraph &g);		///< Construct given a control-flow graph
   int4 getChangeCount(void) const { return dataflow_changecount; }	///< Get number of data-flow changes

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/op.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/op.hh
@@ -176,6 +176,8 @@ public:
   bool isCallOrBranch(void) const { return ((flags&(PcodeOp::branch|PcodeOp::call))!=0); }
   /// \brief Return \b true if this op breaks fall-thru flow
   bool isFlowBreak(void) const { return ((flags&(PcodeOp::branch|PcodeOp::returns))!=0); }
+  /// \brief Return \b true if this op will be decompiled as "return"
+  bool isStandardReturn(void) const { return ((flags&PcodeOp::returns)!=0 && getHaltType()==0); }
   /// \brief Return \b true if this op flips the true/false meaning of its control-flow branching
   bool isBooleanFlip(void) const { return ((flags&PcodeOp::boolean_flip)!=0); }
   /// \brief Return \b true if the fall-thru branch is taken when the boolean input is true


### PR DESCRIPTION
At the moment, when collapsing block, the `ruleBlockIfNoExit` eagerly selects the first noexit branch it find. This merge request introduces some basic heuristics when both branch are noexit to improve the decompiled code's readability.

### heuristic 1 : smallest block depth first
This first heuristic compares the depth in term of generated code block and select the smallest depth.
This tries to flatten the code by preferring small sequential "if return" to nested if blocks.

before | after
:-------------------------:|:-------------------------:
![h1-before](https://user-images.githubusercontent.com/2941350/96918203-3f10e600-14aa-11eb-9d7b-f0632f481bfd.png) | ![h1-after](https://user-images.githubusercontent.com/2941350/96918222-4932e480-14aa-11eb-902a-60533697e7f6.png)

### heuristic 2 : return last
If only one of the branch will end with a `return` in the final code, place it last.
This makes to code closer to what a human would write. 

before | after
:-------------------------:|:-------------------------:
![h2-before](https://user-images.githubusercontent.com/2941350/96918452-98791500-14aa-11eb-8436-6f67ee9b04f0.png) | ![h2-after](https://user-images.githubusercontent.com/2941350/96918460-9c0c9c00-14aa-11eb-8bc1-7641802edf3f.png)

### heuristic 3 : only return
If both branch end with a `return` in the final code and one contains only the return op code, select it.
This also tries to flatten the code as a block containing only a return is most probably a fast logic skip.

before |
:-------------------------:|
![h3-before](https://user-images.githubusercontent.com/2941350/96918551-c3636900-14aa-11eb-841d-1833d81cea22.png) |
 after | 
![h3-after](https://user-images.githubusercontent.com/2941350/96918590-d24a1b80-14aa-11eb-93e3-fbc5551d7bfa.png) |

-----

These heuristics are tried in order (1 to 3) stopping at the first that matches. If none match, we fallback to the previous behavior (selecting the first branch) to only introduce wanted changes.

[Here](https://github.com/NationalSecurityAgency/ghidra/files/5425165/libc_decompile.tar.gz) is the full decompiled code of libc before and after this merge request to compare the diffs on a large binary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added the ability to query the nesting depth of control-flow blocks in the decompiler, providing insight into structural hierarchy.
	- Introduced a method to retrieve the number of operations in a basic block.
	- Added a way to identify standard return operations during decompilation.

- **Improvements**
	- Enhanced the selection logic for identifying the best no-exit clause in conditional blocks, improving control-flow analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->